### PR TITLE
Add Lua-settable aiming FOV

### DIFF
--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -489,8 +489,10 @@ void CSettingsSA::SetRadarMode(eRadarMode hudMode)
 float ms_fFOV = 70;
 float ms_fFOVCar = 70;
 float ms_fFOVCarMax = 100;            // at high vehicle velocity
+float ms_fFOVAiming = 70;
 bool  ms_bFOVPlayerFromScript = false;
 bool  ms_bFOVVehicleFromScript = false;
+bool  ms_bFOVAimingFromScript = false;
 
 // consider moving this to the camera class - qaisjp
 float CSettingsSA::GetFieldOfViewPlayer()
@@ -508,6 +510,11 @@ float CSettingsSA::GetFieldOfViewVehicleMax()
     return ms_fFOVCarMax;
 }
 
+float CSettingsSA::GetFieldOfViewAiming()
+{
+    return ms_fFOVAiming;
+}
+
 void CSettingsSA::UpdateFieldOfViewFromSettings()
 {
     float fFieldOfView;
@@ -516,12 +523,14 @@ void CSettingsSA::UpdateFieldOfViewFromSettings()
     SetFieldOfViewPlayer(fFieldOfView, false);
     SetFieldOfViewVehicle(fFieldOfView, false);
     SetFieldOfViewVehicleMax(100, false);
+    SetFieldOfViewAiming(fFieldOfView, false);
 }
 
 void CSettingsSA::ResetFieldOfViewFromScript()
 {
     ms_bFOVPlayerFromScript = false;
     ms_bFOVVehicleFromScript = false;
+    ms_bFOVAimingFromScript = false;
     UpdateFieldOfViewFromSettings();
 }
 
@@ -557,6 +566,16 @@ void CSettingsSA::SetFieldOfViewVehicleMax(float fAngle, bool bFromScript)
     ms_fFOVCarMax = fAngle;
     MemPut<void*>(0x0524BB4, &ms_fFOVCarMax);
     MemPut<float>(0x0524BC5, ms_fFOVCarMax);
+}
+
+void CSettingsSA::SetFieldOfViewAiming(float fAngle, bool bFromScript)
+{
+    if (!bFromScript && ms_bFOVAimingFromScript)
+        return;
+    ms_bFOVAimingFromScript = bFromScript;
+    ms_fFOVAiming = fAngle;
+    MemPut<float>(0x0858CE0, ms_fFOVAiming);
+    MemPut<float>(0x0B6F250, ms_fFOVAiming);
 }
 
 ////////////////////////////////////////////////

--- a/Client/game_sa/CSettingsSA.h
+++ b/Client/game_sa/CSettingsSA.h
@@ -168,6 +168,8 @@ public:
     float GetFieldOfViewPlayer();
     float GetFieldOfViewVehicle();
     float GetFieldOfViewVehicleMax();
+    void  SetFieldOfViewAiming(float fAngle, bool bFromScript);
+    float GetFieldOfViewAiming();
 
     void SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript);
     void ResetVehiclesLODDistance(bool bForceDefault = false);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -236,6 +236,8 @@ int CLuaCameraDefs::SetCameraFieldOfView(lua_State* luaVM)
                 g_pGame->GetSettings()->SetFieldOfViewVehicle(fFOV, true);
             else if (eMode == FOV_MODE_VEHICLE_MAX)
                 g_pGame->GetSettings()->SetFieldOfViewVehicleMax(fFOV, true);
+            else if (eMode == FOV_MODE_AIMING)
+                g_pGame->GetSettings()->SetFieldOfViewAiming(fFOV, true);
             else
             {
                 argStream.m_iIndex = 1;
@@ -270,6 +272,8 @@ int CLuaCameraDefs::GetCameraFieldOfView(lua_State* luaVM)
             fFOV = g_pGame->GetSettings()->GetFieldOfViewVehicle();
         else if (eMode == FOV_MODE_VEHICLE_MAX)
             fFOV = g_pGame->GetSettings()->GetFieldOfViewVehicleMax();
+        else if (eMode == FOV_MODE_AIMING)
+            fFOV = g_pGame->GetSettings()->GetFieldOfViewAiming();
         else
         {
             argStream.m_iIndex = 1;

--- a/Client/sdk/game/CSettings.h
+++ b/Client/sdk/game/CSettings.h
@@ -162,6 +162,8 @@ public:
     virtual float GetFieldOfViewPlayer() = 0;
     virtual float GetFieldOfViewVehicle() = 0;
     virtual float GetFieldOfViewVehicleMax() = 0;
+    virtual void  SetFieldOfViewAiming(float fAngle, bool bFromScript) = 0;
+    virtual float GetFieldOfViewAiming() = 0;
 
     virtual void SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript) = 0;
     virtual void ResetVehiclesLODDistance(bool bForceDefault = false) = 0;


### PR DESCRIPTION
## Summary
- support setting aiming FOV in SDK interface and SA implementation
- expose aiming FOV through lua camera definitions

## Testing
- `./linux-build.sh --arch=x64 --config=release --cores=1` *(fails: x86_64-linux-gnu-g++-10 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d74b77c808328bfe1e7e679fa8460