### PR TITLE
Add bone scaling functions

### DIFF
--- a/Client/game_sa/CEntitySA.cpp
+++ b/Client/game_sa/CEntitySA.cpp
@@ -649,6 +649,26 @@ bool CEntitySA::SetBonePosition(eBone boneId, const CVector& position)
     return true;
 }
 
+bool CEntitySA::GetBoneScale(eBone boneId, CVector& scale)
+{
+    RwMatrix* rwBoneMatrix = GetBoneRwMatrix(boneId);
+    if (!rwBoneMatrix)
+        return false;
+
+    pGame->GetRenderWareSA()->RwMatrixGetScale(*rwBoneMatrix, scale);
+    return true;
+}
+
+bool CEntitySA::SetBoneScale(eBone boneId, const CVector& scale)
+{
+    RwMatrix* rwBoneMatrix = GetBoneRwMatrix(boneId);
+    if (!rwBoneMatrix)
+        return false;
+
+    pGame->GetRenderWareSA()->RwMatrixSetScale(*rwBoneMatrix, scale);
+    return true;
+}
+
 BYTE CEntitySA::GetAreaCode()
 {
     return m_pInterface->m_areaCode;

--- a/Client/game_sa/CEntitySA.h
+++ b/Client/game_sa/CEntitySA.h
@@ -312,6 +312,8 @@ public:
     bool SetBoneRotationQuat(eBone boneId, float x, float y, float z, float w);
     bool GetBonePosition(eBone boneId, CVector& position);
     bool SetBonePosition(eBone boneId, const CVector& position);
+    bool GetBoneScale(eBone boneId, CVector& scale);
+    bool SetBoneScale(eBone boneId, const CVector& scale);
 
     bool IsOnFire() override { return false; }
     bool SetOnFire(bool onFire) override { return false; }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -39,6 +39,7 @@ void CLuaPedDefs::LoadFunctions()
         {"setElementBoneRotation", ArgumentParserWarn<false, SetElementBoneRotation>},
         {"setElementBoneQuaternion", ArgumentParserWarn<false, SetElementBoneQuaternion>},
         {"setElementBoneMatrix", ArgumentParserWarn<false, SetElementBoneMatrix>},
+        {"setElementBoneScale", ArgumentParserWarn<false, SetElementBoneScale>},
         {"setPedRotation", SetPedRotation},
         {"setPedWeaponSlot", SetPedWeaponSlot},
         {"setPedCanBeKnockedOffBike", SetPedCanBeKnockedOffBike},
@@ -69,6 +70,7 @@ void CLuaPedDefs::LoadFunctions()
         {"getElementBoneRotation", ArgumentParserWarn<false, GetElementBoneRotation>},
         {"getElementBoneQuaternion", ArgumentParserWarn<false, GetElementBoneQuaternion>},
         {"getElementBoneMatrix", ArgumentParserWarn<false, GetElementBoneMatrix>},
+        {"getElementBoneScale", ArgumentParserWarn<false, GetElementBoneScale>},
         {"getPedRotation", GetPedRotation},
         {"getPedWeaponSlot", GetPedWeaponSlot},
         {"canPedBeKnockedOffBike", CanPedBeKnockedOffBike},
@@ -1114,6 +1116,33 @@ bool CLuaPedDefs::SetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone
         return false;
 
     return entity->SetBoneMatrix(static_cast<eBone>(bone), matrix);
+}
+
+std::variant<bool, CLuaMultiReturn<float, float, float>> CLuaPedDefs::GetElementBoneScale(CClientPed* ped, const std::uint16_t bone)
+{
+    if (bone < BONE_ROOT || bone > BONE_LEFTBREAST)
+        throw std::invalid_argument("Invalid bone: " + std::to_string(bone));
+
+    CEntity* entity = ped->GetGameEntity();
+    CVector  scale;
+
+    if (!entity || !entity->GetBoneScale(static_cast<eBone>(bone), scale))
+        return false;
+
+    return CLuaMultiReturn<float, float, float>(scale.fX, scale.fY, scale.fZ);
+}
+
+bool CLuaPedDefs::SetElementBoneScale(CClientPed* ped, const std::uint16_t bone, const CVector scale)
+{
+    if (bone < BONE_ROOT || bone > BONE_LEFTBREAST)
+        throw std::invalid_argument("Invalid bone: " + std::to_string(bone));
+
+    CEntity* entity = ped->GetGameEntity();
+
+    if (!entity)
+        return false;
+
+    return entity->SetBoneScale(static_cast<eBone>(bone), scale);
 }
 
 bool CLuaPedDefs::UpdateElementRpHAnim(CClientPed* ped)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -55,11 +55,13 @@ public:
     static std::variant<bool, CLuaMultiReturn<float, float, float>> GetElementBoneRotation(CClientPed* ped, const std::uint16_t bone);
     static std::variant<bool, CLuaMultiReturn<float, float, float, float>> GetElementBoneQuaternion(CClientPed* ped, const std::uint16_t bone);
     static std::variant<bool, std::array<std::array<float, 4>, 4>>         GetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CLuaMultiReturn<float, float, float>> GetElementBoneScale(CClientPed* ped, const std::uint16_t bone);
 
     static bool SetElementBonePosition(CClientPed* ped, const std::uint16_t bone, const CVector position);
     static bool SetElementBoneRotation(CClientPed* ped, const std::uint16_t bone, const float yaw, const float pitch, const float roll);
     static bool SetElementBoneQuaternion(CClientPed* ped, const std::uint16_t bone, const float x, const float y, const float z, const float w);
     static bool SetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone, const CMatrix matrix);
+    static bool SetElementBoneScale(CClientPed* ped, const std::uint16_t bone, const CVector scale);
 
     static bool UpdateElementRpHAnim(CClientPed* ped);
 

--- a/Client/sdk/game/CEntity.h
+++ b/Client/sdk/game/CEntity.h
@@ -118,6 +118,9 @@ public:
     virtual bool GetBonePosition(eBone boneId, CVector& position) = 0;
     virtual bool SetBonePosition(eBone boneId, const CVector& position) = 0;
 
+    virtual bool GetBoneScale(eBone boneId, CVector& scale) = 0;
+    virtual bool SetBoneScale(eBone boneId, const CVector& scale) = 0;
+
     virtual bool IsOnFire() = 0;
     virtual bool SetOnFire(bool onFire) = 0;
 };


### PR DESCRIPTION
## Summary
- expose bone scaling via new API functions
- implement `SetElementBoneScale` and `GetElementBoneScale`
- add matching game engine methods

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877deff08f483288fa6a7ee300bff00