### PR TITLE
Add clientside command cancellation

### DIFF
--- a/Client/mods/deathmatch/ClientCommands.cpp
+++ b/Client/mods/deathmatch/ClientCommands.cpp
@@ -45,6 +45,18 @@ bool COMMAND_Executed(const char* szCommand, const char* szArguments, bool bHand
             }
         }
 
+        // Give scripts a chance to cancel this command before processing
+        CClientPlayer* localPlayer = g_pClientGame->GetLocalPlayer();
+        if (localPlayer != nullptr)
+        {
+            CLuaArguments cancelArguments;
+            cancelArguments.PushString(szCommandBufferPointer);
+            if (!localPlayer->CallEvent("onClientCommand", cancelArguments, true))
+            {
+                return true;
+            }
+        }
+
         // Toss them together so we can send it to the server
         SString strClumpedCommand;
         if (szArguments && szArguments[0])
@@ -60,7 +72,6 @@ bool COMMAND_Executed(const char* szCommand, const char* szArguments, bool bHand
         g_pClientGame->GetRegisteredCommands()->ProcessCommand(szCommandBufferPointer, szArguments);
 
         // Call the onClientConsole event
-        CClientPlayer* localPlayer = g_pClientGame->GetLocalPlayer();
 
         if (localPlayer != nullptr)
         {

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -2720,6 +2720,7 @@ void CClientGame::AddBuiltInEvents()
     // Console events
     m_Events.AddEvent("onClientConsole", "text", NULL, false);
     m_Events.AddEvent("onClientCoreCommand", "command", NULL, false);
+    m_Events.AddEvent("onClientCommand", "command", NULL, false);
 
     // Chat events
     m_Events.AddEvent("onClientChatMessage", "text, r, g, b, messageType", NULL, false);


### PR DESCRIPTION
## Summary
- allow Lua scripts to intercept client commands via new `onClientCommand` event

## Testing
- `clang-format --version`

------
https://chatgpt.com/codex/tasks/task_e_6877de49d18083288eebb080999eee68