### PR TITLE
Extend bone scale resource

### DIFF
--- a/resources/bone_scale/bonescale.lua
+++ b/resources/bone_scale/bonescale.lua
@@ -1,19 +1,31 @@
-local HEAD_BONE = 8 -- BONE_HEAD
+-- Bones that make up the head/neck chain. These correspond to
+-- BONE_NECK (5) up to BONE_HEAD (8).
+local TARGET_BONES = {5, 6, 7, 8}
 
-local function setHeadScale(scale)
-    setElementBoneScale(localPlayer, HEAD_BONE, scale, scale, scale)
-end
+-- Current scale that should be applied to every bone in TARGET_BONES.
+local currentScale = 1
 
+-- Continuously apply the scale to the player's bones so it stays active
+-- even when animations change.
+addEventHandler("onClientPreRender", root, function()
+    for _, bone in ipairs(TARGET_BONES) do
+        setElementBoneScale(localPlayer, bone, currentScale, currentScale, currentScale)
+    end
+    updateElementRpHAnim(localPlayer)
+end)
+
+-- Command to change the scale of the head/neck bones.
 addCommandHandler("bobble", function(_, value)
     local s = tonumber(value)
     if not s then
         outputChatBox("Usage: /bobble <scale>")
         return
     end
-    setHeadScale(s)
+    currentScale = s
 end)
 
+-- Command to reset the bones to their original size.
 addCommandHandler("nobobble", function()
-    setHeadScale(1)
+    currentScale = 1
 end)
 


### PR DESCRIPTION
## Summary
- extend bonescale logic to handle neck and head bones
- update commands to store and use head/neck scale per-frame

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: no rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6877f3986d8883288d9d1bc696a23337