### PR TITLE
Implement persistent bone scaling

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3890,6 +3890,8 @@ void CClientGame::PostWorldProcessPedsAfterPreRenderHandler()
     CLuaArguments Arguments;
     m_pRootEntity->CallEvent("onClientPedsProcessed", Arguments, false);
 
+    ApplyPedBoneScales();
+
     g_pClientGame->GetModelRenderer()->Update();
 }
 
@@ -7010,6 +7012,67 @@ void CClientGame::InsertPedPointerToSet(CClientPed* pPed)
 void CClientGame::RemovePedPointerFromSet(CClientPed* pPed)
 {
     m_setOfPedPointers.erase(pPed);
+    m_mapPedBoneScales.erase(pPed);
+}
+
+void CClientGame::SetPedBoneScaleCache(CClientPed* ped, eBone bone, const CVector& scale)
+{
+    m_mapPedBoneScales[ped][bone] = scale;
+}
+
+bool CClientGame::GetPedBoneScaleCache(CClientPed* ped, eBone bone, CVector& outScale) const
+{
+    auto pedIt = m_mapPedBoneScales.find(ped);
+    if (pedIt == m_mapPedBoneScales.end())
+        return false;
+    auto boneIt = pedIt->second.find(bone);
+    if (boneIt == pedIt->second.end())
+        return false;
+    outScale = boneIt->second;
+    return true;
+}
+
+void CClientGame::RemovePedBoneScales(CClientPed* ped)
+{
+    m_mapPedBoneScales.erase(ped);
+}
+
+void CClientGame::ApplyPedBoneScales()
+{
+    for (auto& pedEntry : m_mapPedBoneScales)
+    {
+        CClientPed* ped = pedEntry.first;
+        CEntity*    entity = ped->GetGameEntity();
+        if (!entity)
+            continue;
+        RpClump* clump = entity->GetRpClump();
+        for (auto& boneEntry : pedEntry.second)
+        {
+            eBone          bone = boneEntry.first;
+            const CVector& scale = boneEntry.second;
+            RwMatrix*      rwBoneMatrix = entity->GetBoneRwMatrix(bone);
+            if (!rwBoneMatrix)
+                continue;
+
+            CVector right(rwBoneMatrix->right.x, rwBoneMatrix->right.y, rwBoneMatrix->right.z);
+            CVector up(rwBoneMatrix->up.x, rwBoneMatrix->up.y, rwBoneMatrix->up.z);
+            CVector at(rwBoneMatrix->at.x, rwBoneMatrix->at.y, rwBoneMatrix->at.z);
+
+            float curX = right.Length();
+            float curY = up.Length();
+            float curZ = at.Length();
+            if (curX == 0.0f || curY == 0.0f || curZ == 0.0f)
+                continue;
+
+            RwV3d factors = {scale.fX / curX, scale.fY / curY, scale.fZ / curZ};
+            RwMatrixScale(rwBoneMatrix, &factors, rwCOMBINEPRECONCAT);
+
+            CMatrixSAInterface boneMatrix(rwBoneMatrix, false);
+            boneMatrix.UpdateRW();
+        }
+        if (clump)
+            RwFrameUpdateObjects(RpGetFrame(clump));
+    }
 }
 
 CClientPed* CClientGame::GetClientPedByClump(const RpClump& Clump)

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -44,6 +44,7 @@
 #include "CVoiceRecorder.h"
 #include "CSingularFileDownloadManager.h"
 #include "CObjectRespawner.h"
+#include <game/CPed.h>
 
 #define HeliKill_List_Clear_Rate        500
 #define MIN_PUSH_ANTISPAM_RATE          1500
@@ -654,6 +655,11 @@ public:
     void        RemovePedPointerFromSet(CClientPed* pPed);
     CClientPed* GetClientPedByClump(const RpClump& Clump);
 
+    void SetPedBoneScaleCache(CClientPed* ped, eBone bone, const CVector& scale);
+    bool GetPedBoneScaleCache(CClientPed* ped, eBone bone, CVector& outScale) const;
+    void RemovePedBoneScales(CClientPed* ped);
+    void ApplyPedBoneScales();
+
     void OnClientIFPUnload(const std::shared_ptr<CClientIFP>& IFP);
 
     void InsertAnimationAssociationToMap(CAnimBlendAssociationSAInterface* pAnimAssociation, const std::shared_ptr<CIFPAnimations>& pIFPAnimations);
@@ -868,6 +874,7 @@ private:
     // (unsigned int) Key is the hash of custom block name that is supplied to engineLoadIFP
     std::map<unsigned int, std::shared_ptr<CClientIFP> > m_mapOfIfpPointers;
     std::set<CClientPed*>                                m_setOfPedPointers;
+    std::map<CClientPed*, std::map<eBone, CVector>>       m_mapPedBoneScales;
     AnimAssociations_type                                m_mapOfCustomAnimationAssociations;
     // Key is the task and value is the CClientPed*
     RunNamedAnimTask_type m_mapOfRunNamedAnimTasks;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -1073,6 +1073,9 @@ std::variant<bool, CLuaMultiReturn<float, float, float>> CLuaPedDefs::GetElement
         throw std::invalid_argument("Invalid bone: " + std::to_string(bone));
 
     CEntity* entity = ped->GetGameEntity();
+    CVector scale;
+    if (g_pClientGame->GetPedBoneScaleCache(ped, static_cast<eBone>(bone), scale))
+        return CLuaMultiReturn<float, float, float>(scale.fX, scale.fY, scale.fZ);
 
     float sx = 1.0f, sy = 1.0f, sz = 1.0f;
     if (entity && entity->GetBoneScale(static_cast<eBone>(bone), sx, sy, sz))
@@ -1139,8 +1142,12 @@ bool CLuaPedDefs::SetElementBoneScale(CClientPed* ped, std::uint16_t bone, float
         throw std::invalid_argument("Invalid bone: " + std::to_string(bone));
 
     CEntity* entity = ped->GetGameEntity();
+    if (!entity)
+        return false;
 
-    return entity ? entity->SetBoneScale(static_cast<eBone>(bone), scaleX, scaleY, scaleZ) : false;
+    entity->SetBoneScale(static_cast<eBone>(bone), scaleX, scaleY, scaleZ);
+    g_pClientGame->SetPedBoneScaleCache(ped, static_cast<eBone>(bone), CVector(scaleX, scaleY, scaleZ));
+    return true;
 }
 
 bool CLuaPedDefs::UpdateElementRpHAnim(CClientPed* ped)


### PR DESCRIPTION
## Summary
- track bone scales per ped
- reapply bone scales after ped processing
- expose getter and setter backed by scale cache

## Testing
- `./linux-build.sh` *(fails: only generates makefiles)*

------
https://chatgpt.com/codex/tasks/task_e_68794d353b04832898cafc67cf8a09cb