### PR TITLE
Fix missing MemCpyFast and cast for RwMatrixScale

### DIFF
--- a/Client/game_sa/gamesa_renderware.h
+++ b/Client/game_sa/gamesa_renderware.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <game/RenderWare.h>
+#include "gamesa_init.h"
 
 struct CColModelSAInterface;
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -7065,7 +7065,7 @@ void CClientGame::ApplyPedBoneScales()
                 continue;
 
             RwV3d factors = {scale.fX / curX, scale.fY / curY, scale.fZ / curZ};
-            RwMatrixScale(rwBoneMatrix, &factors, rwCOMBINEPRECONCAT);
+            RwMatrixScale(rwBoneMatrix, &factors, (RwTransformOrder)rwCOMBINEPRECONCAT);
 
             CMatrixSAInterface boneMatrix(rwBoneMatrix, false);
             boneMatrix.UpdateRW();


### PR DESCRIPTION
## Summary
- include gamesa_init.h in renderware header so MemCpyFast is found
- cast parameter in ApplyPedBoneScales to match `RwMatrixScale` signature

## Testing
- `echo no tests`

------
https://chatgpt.com/codex/tasks/task_e_687953bb3c408328a07f1d9904be6f05