### PR TITLE
Allow FOV adjustment while aiming

### DIFF
--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -491,8 +491,10 @@ void CSettingsSA::SetRadarMode(eRadarMode hudMode)
 float ms_fFOV = 70;
 float ms_fFOVCar = 70;
 float ms_fFOVCarMax = 100;            // at high vehicle velocity
+float ms_fFOVAiming = 70;
 bool  ms_bFOVPlayerFromScript = false;
 bool  ms_bFOVVehicleFromScript = false;
+bool  ms_bFOVAimingFromScript = false;
 
 // consider moving this to the camera class - qaisjp
 float CSettingsSA::GetFieldOfViewPlayer()
@@ -508,6 +510,11 @@ float CSettingsSA::GetFieldOfViewVehicle()
 float CSettingsSA::GetFieldOfViewVehicleMax()
 {
     return ms_fFOVCarMax;
+}
+
+float CSettingsSA::GetFieldOfViewAiming()
+{
+    return ms_fFOVAiming;
 }
 
 void CSettingsSA::UpdateFieldOfViewFromSettings()
@@ -596,6 +603,37 @@ void CSettingsSA::SetFieldOfViewVehicleMax(float fAngle, bool bFromScript, bool 
     // CCam::Process_FollowCar_SA
     MemPut<void*>(0x0524BB4, &ms_fFOVCarMax);
     MemPut<float>(0x0524BC5, ms_fFOVCarMax);
+}
+
+void CSettingsSA::SetFieldOfViewAiming(float fAngle, bool bFromScript, bool instant)
+{
+    if (!bFromScript && ms_bFOVAimingFromScript)
+        return;
+
+    ms_bFOVAimingFromScript = bFromScript;
+    ms_fFOVAiming = fAngle;
+
+    if (instant)
+    {
+        const auto pair = GetActiveCamPlusMode();
+
+        switch (pair.second)
+        {
+            case MODE_AIMWEAPON:
+            case MODE_AIMWEAPON_FROMCAR:
+            case MODE_AIMWEAPON_ATTACHED:
+            case MODE_M16_1STPERSON:
+            case MODE_ROCKETLAUNCHER:
+            case MODE_ROCKETLAUNCHER_HS:
+            case MODE_HELICANNON_1STPERSON:
+            case MODE_CAMERA:
+            case MODE_SNIPER:
+                pair.first->SetFOV(fAngle);
+                break;
+            default:
+                break;
+        }
+    }
 }
 
 ////////////////////////////////////////////////

--- a/Client/game_sa/CSettingsSA.h
+++ b/Client/game_sa/CSettingsSA.h
@@ -165,9 +165,11 @@ public:
     void  SetFieldOfViewPlayer(float fAngle, bool bFromScript, bool instant = false);
     void  SetFieldOfViewVehicle(float fAngle, bool bFromScript, bool instant = false);
     void  SetFieldOfViewVehicleMax(float fAngle, bool bFromScript, bool instant = false);
+    void  SetFieldOfViewAiming(float fAngle, bool bFromScript, bool instant = false);
     float GetFieldOfViewPlayer();
     float GetFieldOfViewVehicle();
     float GetFieldOfViewVehicleMax();
+    float GetFieldOfViewAiming();
 
     void SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript);
     void ResetVehiclesLODDistance(bool bForceDefault = false);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -244,6 +244,10 @@ int CLuaCameraDefs::SetCameraFieldOfView(lua_State* luaVM)
             {
                 g_pGame->GetSettings()->SetFieldOfViewVehicleMax(fFOV, true, instant);
             }
+            else if (eMode == FOV_MODE_AIMING)
+            {
+                g_pGame->GetSettings()->SetFieldOfViewAiming(fFOV, true, instant);
+            }
             else
             {
                 argStream.m_iIndex = 1;
@@ -278,6 +282,8 @@ int CLuaCameraDefs::GetCameraFieldOfView(lua_State* luaVM)
             fFOV = g_pGame->GetSettings()->GetFieldOfViewVehicle();
         else if (eMode == FOV_MODE_VEHICLE_MAX)
             fFOV = g_pGame->GetSettings()->GetFieldOfViewVehicleMax();
+        else if (eMode == FOV_MODE_AIMING)
+            fFOV = g_pGame->GetSettings()->GetFieldOfViewAiming();
         else
         {
             argStream.m_iIndex = 1;

--- a/Client/sdk/game/CSettings.h
+++ b/Client/sdk/game/CSettings.h
@@ -158,10 +158,12 @@ public:
     virtual void SetFieldOfViewPlayer(float fAngle, bool bFromScript, bool instant = false) = 0;
     virtual void SetFieldOfViewVehicle(float fAngle, bool bFromScript, bool instant = false) = 0;
     virtual void SetFieldOfViewVehicleMax(float fAngle, bool bFromScript, bool instant = false) = 0;
+    virtual void SetFieldOfViewAiming(float fAngle, bool bFromScript, bool instant = false) = 0;
 
     virtual float GetFieldOfViewPlayer() = 0;
     virtual float GetFieldOfViewVehicle() = 0;
     virtual float GetFieldOfViewVehicleMax() = 0;
+    virtual float GetFieldOfViewAiming() = 0;
 
     virtual void SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript) = 0;
     virtual void ResetVehiclesLODDistance(bool bForceDefault = false) = 0;


### PR DESCRIPTION
## Summary
- extend settings system to store a new aiming FOV value
- expose Set/GetCameraFieldOfView for aiming mode
- implement helper to adjust camera FOV instantly when aiming

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68889add737c83289698ff3b85ae878f