### PR TITLE
Fix aiming FOV reset on script release

### DIFF
--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -525,12 +525,15 @@ void CSettingsSA::UpdateFieldOfViewFromSettings()
     SetFieldOfViewPlayer(fFieldOfView, false);
     SetFieldOfViewVehicle(fFieldOfView, false);
     SetFieldOfViewVehicleMax(100, false);
+    // Use the same base FOV for aiming when not overridden by scripts
+    SetFieldOfViewAiming(fFieldOfView, false);
 }
 
 void CSettingsSA::ResetFieldOfViewFromScript()
 {
     ms_bFOVPlayerFromScript = false;
     ms_bFOVVehicleFromScript = false;
+    ms_bFOVAimingFromScript = false;
     UpdateFieldOfViewFromSettings();
 }
 


### PR DESCRIPTION
## Summary
- ensure UpdateFieldOfViewFromSettings also resets aiming FOV
- clear ms_bFOVAimingFromScript when releasing script control

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888a0ff183083288348dfae64689980