### PR TITLE
Add fov_aiming client setting

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -349,6 +349,8 @@ void CClientVariables::LoadDefaults()
     DEFAULT("share_file_cache", 1);                                                   // 0-no 1-share client resource file cache with other MTA installs
     DEFAULT("show_unsafe_resolutions", 0);                                            // 0-off 1-show resolutions that are higher that the desktop
     DEFAULT("fov", 70);                                                               // Camera field of view
+    DEFAULT("fov_aiming", 70);
+      // Camera field of view while aiming
     DEFAULT("browser_remote_websites", true);                                         // Load remote websites?
     DEFAULT("browser_remote_javascript", true);                                       // Execute javascript on remote websites?
     DEFAULT("filter_duplicate_log_lines", true);                                      // Filter duplicate log lines for debug view and clientscript.log

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1873,6 +1873,7 @@ bool CSettings::OnVideoDefaultClick(CGUIElement* pElement)
 
     CVARS_SET("aspect_ratio", ASPECT_RATIO_AUTO);
     CVARS_SET("fov", 70);
+    CVARS_SET("fov_aiming", 70);
     CVARS_SET("anisotropic", 0);
     CVARS_SET("volumetric_shadows", false);
     CVARS_SET("grass", true);

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -525,8 +525,11 @@ void CSettingsSA::UpdateFieldOfViewFromSettings()
     SetFieldOfViewPlayer(fFieldOfView, false);
     SetFieldOfViewVehicle(fFieldOfView, false);
     SetFieldOfViewVehicleMax(100, false);
-    // Use the same base FOV for aiming when not overridden by scripts
-    SetFieldOfViewAiming(fFieldOfView, false);
+
+    float fFieldOfViewAiming = fFieldOfView;
+    g_pCore->GetCVars()->Get("fov_aiming", fFieldOfViewAiming);
+    fFieldOfViewAiming = Clamp(70.f, fFieldOfViewAiming, 100.f);
+    SetFieldOfViewAiming(fFieldOfViewAiming, false);
 }
 
 void CSettingsSA::ResetFieldOfViewFromScript()


### PR DESCRIPTION
## Summary
- add `fov_aiming` to default client variables
- allow FOV aiming to be loaded from settings
- reset to default aiming FOV on "Load Defaults"

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6888a24f5db88328b0090ac247de38d9