### PR TITLE
Fix custom vehicle audio affecting subsequent spawns

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -5146,6 +5146,10 @@ void CClientVehicle::ApplyAudioSettings()
 
     g_pGame->GetVehicleAudioSettingsManager()->SetNextSettings(&GetAudioSettings());
     m_pVehicle->ReinitAudio();
+
+    // Reset next settings to model defaults so future vehicles created by GTA
+    // don't inherit this vehicle's custom audio setup
+    g_pGame->GetVehicleAudioSettingsManager()->SetNextSettings(m_usModel);
 }
 
 void CClientVehicle::ResetAudioSettings()


### PR DESCRIPTION
## Summary
- ensure the audio manager pointer is reset to defaults after applying custom vehicle settings

## Testing
- `./linux-build.sh` *(fails: x86_64-linux-gnu-g++-10 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b15cfc6c8328b56dc8f845c82d2c