### PR TITLE
Fix ResetVehicleModelAudioSettings return

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -4503,7 +4503,8 @@ bool CLuaVehicleDefs::ResetVehicleModelAudioSettings(const uint32_t uiModel)
     if (!CClientVehicleManager::IsStandardModel(uiModel))
         throw std::invalid_argument("Cannot change audio setting for allocated vechiles");
 
-     g_pGame->GetVehicleAudioSettingsManager()->ResetModelSettings(uiModel);
+    g_pGame->GetVehicleAudioSettingsManager()->ResetModelSettings(uiModel);
+    return true;
 }
 
 bool CLuaVehicleDefs::SetVehicleAudioSetting(CClientVehicle* pVehicle, const VehicleAudioSettingProperty eProperty, float varValue)


### PR DESCRIPTION
## Summary
- ensure `ResetVehicleModelAudioSettings` returns `true`

## Testing
- `g++ -std=c++17 -Wall -Wextra -IClient/mods/deathmatch -IClient/sdk -IClient/sdk/game -IShared/mods/deathmatch/logic -IShared/mods/deathmatch -IShared/sdk -c Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp -o /tmp/test.o` *(fails: `windows.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888b3011d8083288d2c3bac751cb3dc